### PR TITLE
Fix SHA-1 of file.txt v2 to match diagrams

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -148,7 +148,7 @@ It does up to three basic operations.
 
 The first thing `reset` will do is move what HEAD points to.
 This isn't the same as changing HEAD itself (which is what `checkout` does); `reset` moves the branch that HEAD is pointing to.
-This means if HEAD is set to the `master` branch (i.e. you're currently on the `master` branch), running `git reset 9e5e64a` will start by making `master` point to `9e5e64a`.
+This means if HEAD is set to the `master` branch (i.e. you're currently on the `master` branch), running `git reset 9e5e6a4` will start by making `master` point to `9e5e6a4`.
 
 image::images/reset-soft.png[]
 


### PR DESCRIPTION
The SHA-1 of `file.txt` in the diagrams is `9e5e6a4` but the text refers to `9e5e64a`.  Since I'm assuming either hash is fine, I've changed the text to match the diagram since I figure that's an easier change.
